### PR TITLE
use normalized macro name

### DIFF
--- a/php_uv.c
+++ b/php_uv.c
@@ -6503,7 +6503,7 @@ PHP_MINFO_FUNCTION(uv)
 	php_printf("PHP libuv Extension\n");
 	php_info_print_table_start();
 	php_info_print_table_header(2,"libuv Support",  "enabled");
-	php_info_print_table_row(2,"Version", PHP_UV_EXTVER);
+	php_info_print_table_row(2,"Version", PHP_UV_VERSION);
 	php_info_print_table_row(2,"libuv Version", uv_version);
 //	php_info_print_table_row(2,"http-parser Version", http_parser_version);
 	php_info_print_table_end();
@@ -6518,7 +6518,7 @@ zend_module_entry uv_module_entry = {
 	NULL,					/* RINIT */
 	PHP_RSHUTDOWN(uv),		/* RSHUTDOWN */
 	PHP_MINFO(uv),	/* MINFO */
-	PHP_UV_EXTVER,
+	PHP_UV_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
 

--- a/php_uv.h
+++ b/php_uv.h
@@ -3,7 +3,7 @@
 #define PHP_UV_H
 
 #define PHP_UV_EXTNAME "uv"
-#define PHP_UV_EXTVER "0.0.2"
+#define PHP_UV_VERSION "0.0.2"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
As this one is checked on pecl upload (to ensure it matches package version, which is a quite common mistake)