### PR TITLE
use pkg-config when available

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -44,36 +44,52 @@ if test $PHP_UV != "no"; then
 
     PHP_ADD_EXTENSION_DEP(uv, sockets, true)
 
-    SEARCH_PATH="/usr/local /usr"
-    SEARCH_FOR="/include/uv.h"
-    if test -r $PHP_UV/$SEARCH_FOR; then # path given as parameter
-       UV_DIR=$PHP_UV
-    else # search default path list
-       AC_MSG_CHECKING([for libuv files in default path])
-       for i in $SEARCH_PATH ; do
-           if test -r $i/$SEARCH_FOR; then
-             UV_DIR=$i
-             AC_MSG_RESULT(found in $i)
-           fi
-       done
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+
+    AC_MSG_CHECKING(for libuv)
+
+    if test $PHP_UV == "yes" && test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libuv; then
+      if $PKG_CONFIG libuv --atleast-version 1.0.0; then
+        LIBUV_INCLINE=`$PKG_CONFIG libuv --cflags`
+        LIBUV_LIBLINE=`$PKG_CONFIG libuv --libs`
+        LIBUV_VERSION=`$PKG_CONFIG libuv --modversion`
+        AC_MSG_RESULT(from pkgconfig: found version $LIBUV_VERSION)
+        AC_DEFINE(HAVE_UVLIB,1,[ ])
+      else
+        AC_MSG_ERROR(system libuv must be upgraded to version >= 1.0.0)
+      fi
+      PHP_EVAL_LIBLINE($LIBUV_LIBLINE, UV_SHARED_LIBADD)
+      PHP_EVAL_INCLINE($LIBUV_INCLINE)
+
+    else
+      SEARCH_PATH="/usr/local /usr"
+      SEARCH_FOR="/include/uv.h"
+      if test -r $PHP_UV/$SEARCH_FOR; then # path given as parameter
+         UV_DIR=$PHP_UV
+         AC_MSG_RESULT(from option: found in $UV_DIR)
+      else # search default path list
+         for i in $SEARCH_PATH ; do
+             if test -r $i/$SEARCH_FOR; then
+               UV_DIR=$i
+               AC_MSG_RESULT(from default path: found in $i)
+             fi
+         done
+      fi
+      PHP_ADD_INCLUDE($UV_DIR/include)
+      PHP_CHECK_LIBRARY(uv, uv_version,
+      [
+        PHP_ADD_LIBRARY_WITH_PATH(uv, $UV_DIR/$PHP_LIBDIR, UV_SHARED_LIBADD)
+        AC_DEFINE(HAVE_UVLIB,1,[ ])
+      ],[
+        AC_MSG_ERROR([wrong uv library version or library not found])
+      ],[
+        -L$UV_DIR/$PHP_LIBDIR -lm
+      ])
+      case $host in
+          *linux*)
+              CFLAGS="$CFLAGS -lrt"
+      esac
     fi
-
-    PHP_ADD_INCLUDE($UV_DIR/include)
-
-    PHP_CHECK_LIBRARY(uv, uv_version,
-    [
-      PHP_ADD_LIBRARY_WITH_PATH(uv, $UV_DIR/$PHP_LIBDIR, UV_SHARED_LIBADD)
-      AC_DEFINE(HAVE_UVLIB,1,[ ])
-    ],[
-      AC_MSG_ERROR([wrong uv library version or library not found])
-    ],[
-      -L$UV_DIR/$PHP_LIBDIR -lm
-    ])
-
-	case $host in
-        *linux*)
-            CFLAGS="$CFLAGS -lrt"
-    esac
 
 	PHP_SUBST([CFLAGS])
     PHP_SUBST(UV_SHARED_LIBADD)


### PR DESCRIPTION
TODO: know what is the real minimal version needed

Fopr pkg-config case, just adapt
`      if $PKG_CONFIG libuv --atleast-version 1.0.0; then`

For falback case, need to adapt (with some more recently added  symbol)
`      PHP_CHECK_LIBRARY(uv, uv_version,`

Some candidates (not found on old versions): uv_fs_scandir, uv_loop_close, uv_loop_init, uv_pipe_pending_count, uv_fs_event_start...)
