### PR TITLE
[-Wincompatible-pointer-types]

### DIFF
--- a/php_uv.c
+++ b/php_uv.c
@@ -2432,7 +2432,11 @@ int php_uv_cast_object(zval *readobj_zv, zval *writeobj, int type) {
 		ZVAL_LONG(writeobj, readobj->handle);
 		return SUCCESS;
 	} else {
+#if PHP_VERSION_ID >= 80000
 		return zend_std_cast_object_tostring(readobj, writeobj, type);
+#else
+		return zend_std_cast_object_tostring(readobj_zv, writeobj, type);
+#endif
 	}
 }
 


### PR DESCRIPTION
```
/work/GIT/pecl-and-ext/uv/php_uv.c: In function 'php_uv_cast_object':
/work/GIT/pecl-and-ext/uv/php_uv.c:2435:40: warning: passing argument 1 of 'zend_std_cast_object_tostring' from incompatible pointer type [-Wincompatible-pointer-types]
   return zend_std_cast_object_tostring(readobj, writeobj, type);
                                        ^~~~~~~
In file included from /usr/include/php/Zend/zend.h:327,
                 from /usr/include/php/main/php.h:35,
                 from /work/GIT/pecl-and-ext/uv/php_uv.h:32,
                 from /work/GIT/pecl-and-ext/uv/php_uv.c:21:
/usr/include/php/Zend/zend_object_handlers.h:171:50: note: expected 'zval *' {aka 'struct _zval_struct *'} but argument is of type 'zend_object *' {aka 'struct _zend_object *'}
 ZEND_API int zend_std_cast_object_tostring(zval *readobj, zval *writeobj, int type);
                                            ~~~~~~^~~~~~~

```