### PR TITLE
fix: remove orphan ADDREF which causes resource leaks (#118)

### DIFF
--- a/php_uv.c
+++ b/php_uv.c
@@ -841,8 +841,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			PHP_UV_FS_PARSE_PARAMETERS(2, Z_PARAM_RESOURCE(zstream) Z_PARAM_LONG(mode));
 			PHP_UV_FS_SETUP();
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			PHP_UV_FS_ASYNC(loop, fchmod, fd, mode);
 			break;
 		}
@@ -888,8 +886,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			PHP_UV_FS_PARSE_PARAMETERS(2, Z_PARAM_RESOURCE(zstream) Z_PARAM_LONG(offset));
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			PHP_UV_FS_ASYNC(loop, ftruncate, fd, offset);
 			break;
 		}
@@ -901,8 +897,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			PHP_UV_FS_PARSE_PARAMETERS(1, Z_PARAM_RESOURCE(zstream));
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			PHP_UV_FS_ASYNC(loop, fdatasync, fd);
 			break;
 		}
@@ -914,8 +908,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			PHP_UV_FS_PARSE_PARAMETERS(1, Z_PARAM_RESOURCE(zstream));
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			PHP_UV_FS_ASYNC(loop, fsync, fd);
 			break;
 		}
@@ -923,13 +915,26 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 		{
 			zval *zstream = NULL;
 			unsigned long fd;
+			int dup_fd;
 
 			PHP_UV_FS_PARSE_PARAMETERS(1, Z_PARAM_RESOURCE(zstream));
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
-			PHP_UV_FS_ASYNC(loop, close, fd);
+
+			/* The wrapping php_stream still owns the original fd and will
+			 * close() it from its destructor when the resource is released.
+			 * Pass a dup() to libuv so the libuv async close targets a
+			 * separate fd number — otherwise libuv frees the fd in the
+			 * kernel before the stream destructor runs, the kernel may
+			 * recycle the fd number for an unrelated open, and the stream
+			 * destructor's close() then hits the wrong file. */
+			dup_fd = dup((int) fd);
+			if (dup_fd < 0) {
+				PHP_UV_DEINIT_UV(uv);
+				php_error_docref(NULL, E_ERROR, "uv_fs_close: dup() failed: %s", strerror(errno));
+				return;
+			}
+			PHP_UV_FS_ASYNC(loop, close, dup_fd);
 			break;
 		}
 		case UV_FS_CHOWN:
@@ -950,8 +955,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			PHP_UV_FS_PARSE_PARAMETERS(3, Z_PARAM_RESOURCE(zstream) Z_PARAM_LONG(uid) Z_PARAM_LONG(gid));
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			PHP_UV_FS_ASYNC(loop, fchown, fd, uid, gid);
 			break;
 		}
@@ -995,8 +998,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			PHP_UV_FS_PARSE_PARAMETERS_EX(1, Z_PARAM_RESOURCE(zstream), 1);
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			PHP_UV_FS_ASYNC(loop, fstat, fd);
 			break;
 		}
@@ -1026,8 +1027,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			PHP_UV_FS_PARSE_PARAMETERS(3, Z_PARAM_RESOURCE(zstream) Z_PARAM_LONG(utime) Z_PARAM_LONG(atime));
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			PHP_UV_FS_ASYNC(loop, futime, fd, utime, atime);
 			break;
 		}
@@ -1056,8 +1055,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			}
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 
 			uv->buffer = (char*) emalloc(length);
 			buf = uv_buf_init(uv->buffer, length);
@@ -1076,10 +1073,9 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			/* TODO */
 			PHP_UV_ZVAL_TO_FD(in_fd, z_instream);
 			PHP_UV_ZVAL_TO_FD(out_fd, z_outstream);
-			uv->fs_fd = *z_outstream;
-			Z_ADDREF(uv->fs_fd);
-			uv->fs_fd_alt = *z_instream;
-			Z_ADDREF(uv->fs_fd_alt);
+			ZVAL_COPY_VALUE(&uv->fs_fd_alt, &uv->fs_fd);
+			/* The second PHP_UV_ZVAL_TO_FD() doesn't increment its refcount, so increment it here */
+			ZVAL_COPY(&uv->fs_fd, z_outstream);
 			PHP_UV_FS_ASYNC(loop, sendfile, in_fd, out_fd, offset, length);
 			break;
 		}
@@ -1100,8 +1096,6 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			ZEND_PARSE_PARAMETERS_END();
 			PHP_UV_FS_SETUP();
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			uv->fs_fd = *zstream;
-			Z_ADDREF(uv->fs_fd);
 			uv->buffer = estrndup(buffer->val, buffer->len);
 
 			/* TODO: is this right?! */
@@ -1865,6 +1859,12 @@ static void php_uv_fs_cb(uv_fs_t* req)
 	}
 
 	switch (uv->uv.fs.fs_type) {
+		case UV_FS_CLOSE:
+			argc = 1;
+			zval_ptr_dtor(&params[0]);
+			ZVAL_LONG(&params[0], uv->uv.fs.result);
+			break;
+
 		case UV_FS_SYMLINK:
 		case UV_FS_LINK:
 		case UV_FS_CHMOD:
@@ -1872,7 +1872,6 @@ static void php_uv_fs_cb(uv_fs_t* req)
 		case UV_FS_UNLINK:
 		case UV_FS_RMDIR:
 		case UV_FS_MKDIR:
-		case UV_FS_CLOSE:
 		case UV_FS_CHOWN:
 		case UV_FS_UTIME:
 		case UV_FS_FUTIME:

--- a/tests/399-fs-close-refcount-leak-issue-118.phpt
+++ b/tests/399-fs-close-refcount-leak-issue-118.phpt
@@ -1,0 +1,34 @@
+--TEST--
+uv_fs_open + uv_fs_close in a loop should not leak refcount (issue 118)
+--FILE--
+<?php
+$loop = uv_default_loop();
+$path = tempnam(sys_get_temp_dir(), 'uvtest_');
+
+$one = function () use ($loop, $path) {
+    $done = false;
+    uv_fs_open($loop, $path, UV::O_WRONLY, 0, function ($stream) use (&$done, $loop) {
+        uv_fs_close($loop, $stream, function () use (&$done) {
+            $done = true;
+        });
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+};
+
+// Warm up to settle allocator
+$one();
+
+$baseline = memory_get_usage();
+for ($i = 0; $i < 1000; $i++) {
+    $one();
+}
+
+$delta = memory_get_usage() - $baseline;
+echo $delta < 4096 ? "OK\n" : "LEAK ($delta bytes)\n";
+
+unlink($path);
+?>
+--EXPECT--
+OK

--- a/tests/399-fs-close-refcount-observe-issue-118.phpt
+++ b/tests/399-fs-close-refcount-observe-issue-118.phpt
@@ -1,0 +1,42 @@
+--TEST--
+uv_fs_close should not bump the resource refcount (issue 118)
+--FILE--
+<?php
+$loop = uv_default_loop();
+$path = tempnam(sys_get_temp_dir(), 'uvtest_');
+
+$stream = null;
+$done = false;
+uv_fs_open($loop, $path, UV::O_WRONLY, 0, function ($opened) use (&$stream, &$done) {
+    $stream = $opened;
+    $done = true;
+});
+while (!$done) {
+    uv_run($loop, UV::RUN_ONCE);
+}
+
+// rc before close (in arg context, +1 for debug_zval_dump)
+ob_start();
+debug_zval_dump($stream);
+$before = ob_get_clean();
+
+$done = false;
+uv_fs_close($loop, $stream, function () use (&$done) {
+    $done = true;
+});
+while (!$done) {
+    uv_run($loop, UV::RUN_ONCE);
+}
+
+ob_start();
+debug_zval_dump($stream);
+$after = ob_get_clean();
+
+preg_match('/refcount\((\d+)\)/', $before, $b);
+preg_match('/refcount\((\d+)\)/', $after, $a);
+echo "rc unchanged: " . ($b[1] === $a[1] ? "yes" : "no ($b[1] -> $a[1])") . "\n";
+
+unlink($path);
+?>
+--EXPECT--
+rc unchanged: yes

--- a/tests/399-fs-sendfile-refcount-leak-issue-118.phpt
+++ b/tests/399-fs-sendfile-refcount-leak-issue-118.phpt
@@ -1,0 +1,72 @@
+--TEST--
+uv_fs_sendfile in a loop should not leak (issue 118)
+--FILE--
+<?php
+$loop = uv_default_loop();
+$src = tempnam(sys_get_temp_dir(), 'uvsrc_');
+file_put_contents($src, str_repeat('x', 256));
+$dst = tempnam(sys_get_temp_dir(), 'uvdst_');
+
+// helper to do one open/sendfile/close cycle synchronously
+$one = function () use ($loop, $src, $dst) {
+    $in = null;
+    $out = null;
+    $done = false;
+    uv_fs_open($loop, $src, UV::O_RDONLY, 0, function ($opened) use (&$in, &$done) {
+        $in = $opened;
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+
+    $done = false;
+    uv_fs_open($loop, $dst, UV::O_WRONLY | UV::O_CREAT, 0644, function ($opened) use (&$out, &$done) {
+        $out = $opened;
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+
+    $done = false;
+    uv_fs_sendfile($loop, $out, $in, 0, 256, function () use (&$done) {
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+
+    $done = false;
+    uv_fs_close($loop, $in, function () use (&$done) {
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+
+    $done = false;
+    uv_fs_close($loop, $out, function () use (&$done) {
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+};
+
+/* warm up to settle the allocator */
+$one();
+
+$base = memory_get_usage();
+for ($i = 0; $i < 500; $i++) {
+    $one();
+}
+
+$delta = memory_get_usage() - $base;
+echo $delta < 4096 ? "OK\n" : "LEAK ($delta bytes)\n";
+
+unlink($src);
+unlink($dst);
+?>
+--EXPECT--
+OK

--- a/tests/399-fs-write-refcount-leak-issue-118.phpt
+++ b/tests/399-fs-write-refcount-leak-issue-118.phpt
@@ -1,0 +1,53 @@
+--TEST--
+uv_fs_write does not leak resource refcount (issue 118)
+--SKIPIF--
+<?php
+if (!extension_loaded('uv')) die("skip uv ext not loaded");
+?>
+--FILE--
+<?php
+$loop = uv_default_loop();
+$path = tempnam(sys_get_temp_dir(), 'uvtest_');
+$one = function () use ($loop, $path) {
+    $stream = null;
+    $done = false;
+    uv_fs_open($loop, $path, UV::O_WRONLY, 0, function ($opened) use (&$stream, &$done) {
+        $stream = $opened;
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+
+    $done = false;
+    uv_fs_write($loop, $stream, "hello\n", 0, function () use (&$done) {
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+
+    $done = false;
+    uv_fs_close($loop, $stream, function () use (&$done) {
+        $done = true;
+    });
+    while (!$done) {
+        uv_run($loop, UV::RUN_ONCE);
+    }
+};
+
+/* warm up to settle the allocator */
+$one();
+
+$baseline = memory_get_usage();
+for ($i = 0; $i < 1000; $i++) {
+    $one();
+}
+
+$delta = memory_get_usage() - $baseline;
+echo $delta < 4096 ? "OK\n" : "LEAK ($delta bytes)\n";
+
+unlink($path);
+?>
+--EXPECT--
+OK


### PR DESCRIPTION
Resolves #118

First use of `PHP_UV_ZVAL_TO_FD()` after `PHP_UV_FS_SETUP()` already adds the refcount, and there are no matching DECREF for those explicit ADDREFs. So those extra additions cause resource leaks.

Note: This leak is hiding another bug. In other words, fixing only the leak exposes a double-close race. Call to `PHP_UV_FD_TO_ZVAL()` in `uv_fs_open()` wraps the fd in a php_stream via `php_stream_fopen_from_fd()`. The stream owns that fd: when the resource hits refcount 0, the stream destructor calls `close(fd)`. But `uv_fs_close()` also closes the same fd via libuv. The libuv close happens promptly (async, completes before the cb returns to the script). The stream destructor's close happens later, when the PHP-side resource finally drops to refcount 0.

The extra refcount removed by this PR has been preventing that the refcount actually drops to 0, so the double-close bug has been fortunately(?) hidden. The double-close bug is fixed in this PR too.

The following issues should be fixed by this PR.
https://github.com/amphp/file/issues/88
https://github.com/reactphp/filesystem/issues/120
